### PR TITLE
Remove getAttachedRecyclerView()

### DIFF
--- a/adapter-toolbox/src/main/java/net/cattaka/android/adaptertoolbox/adapter/AbsTreeItemAdapter.java
+++ b/adapter-toolbox/src/main/java/net/cattaka/android/adaptertoolbox/adapter/AbsTreeItemAdapter.java
@@ -30,7 +30,7 @@ public abstract class AbsTreeItemAdapter<
     private Context mContext;
     private List<W> mItems;
 
-    private RecyclerView mRecyclerView;
+    private ListenerRelay<A, VH> mListenerRelay;
 
     @NonNull
     protected static <T extends ITreeItem<T>, W extends AbsTreeItemAdapter.WrappedItem<W, T>, REF extends ITreeItemAdapterRef<?, ?, T, W>>
@@ -50,7 +50,7 @@ public abstract class AbsTreeItemAdapter<
     }
 
     public <REF extends ITreeItemAdapterRef<A, ?, T, W>> AbsTreeItemAdapter(@NonNull Context context, @NonNull List<T> items, @NonNull REF ref) {
-        super(new ForwardingListener<A, VH>());
+        super();
         mContext = context;
         mItems = inflateWrappedList(new ArrayList<W>(), items, 0, null, ref);
     }
@@ -151,25 +151,18 @@ public abstract class AbsTreeItemAdapter<
         }
     }
 
-    @Nullable
-    public RecyclerView getAttachedRecyclerView() {
-        return mRecyclerView;
-    }
-
-    @Override
-    public void onAttachedToRecyclerView(RecyclerView recyclerView) {
-        super.onAttachedToRecyclerView(recyclerView);
-        mRecyclerView = recyclerView;
-    }
-
-    @Override
-    public void onDetachedFromRecyclerView(RecyclerView recyclerView) {
-        super.onDetachedFromRecyclerView(recyclerView);
-        mRecyclerView = null;
-    }
-
     public void setListenerRelay(@Nullable ListenerRelay<A, VH> listenerRelay) {
-        getForwardingListener().setListenerRelay(listenerRelay);
+        mListenerRelay = listenerRelay;
+    }
+
+    @NonNull
+    @Override
+    public ForwardingListener<A, VH> createForwardingListener() {
+        ForwardingListener<A, VH> forwardingListener = new ForwardingListener<>();
+        if (mListenerRelay != null) {
+            forwardingListener.setListenerRelay(mListenerRelay);
+        }
+        return forwardingListener;
     }
 
     public interface ITreeItemAdapterRef<

--- a/adapter-toolbox/src/main/java/net/cattaka/android/adaptertoolbox/adapter/CustomRecyclerAdapter.java
+++ b/adapter-toolbox/src/main/java/net/cattaka/android/adaptertoolbox/adapter/CustomRecyclerAdapter.java
@@ -1,5 +1,6 @@
 package net.cattaka.android.adaptertoolbox.adapter;
 
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.widget.RecyclerView;
 
@@ -20,11 +21,23 @@ public abstract class CustomRecyclerAdapter<
         ForwardingListener<A, VH>
         > {
 
+    private ListenerRelay<A, VH> mListenerRelay;
+
     public CustomRecyclerAdapter() {
-        super(new ForwardingListener<A, VH>());
+        super();
     }
 
     public void setListenerRelay(@Nullable ListenerRelay<A, VH> listenerRelay) {
-        getForwardingListener().setListenerRelay(listenerRelay);
+        mListenerRelay = listenerRelay;
+    }
+
+    @NonNull
+    @Override
+    public ForwardingListener<A, VH> createForwardingListener() {
+        ForwardingListener<A, VH> forwardingListener = new ForwardingListener<>();
+        if (mListenerRelay != null) {
+            forwardingListener.setListenerRelay(mListenerRelay);
+        }
+        return forwardingListener;
     }
 }

--- a/adapter-toolbox/src/main/java/net/cattaka/android/adaptertoolbox/adapter/SingleViewAdapter.java
+++ b/adapter-toolbox/src/main/java/net/cattaka/android/adaptertoolbox/adapter/SingleViewAdapter.java
@@ -32,8 +32,8 @@ public class SingleViewAdapter extends CustomRecyclerAdapter<SingleViewAdapter, 
         RecyclerView.ViewHolder vh = new RecyclerView.ViewHolder(view) {
         };
 
-        view.setOnClickListener(getForwardingListener());
-        view.setOnLongClickListener(getForwardingListener());
+        view.setOnClickListener(getForwardingListener(parent));
+        view.setOnLongClickListener(getForwardingListener(parent));
 
         return vh;
     }

--- a/adapter-toolbox/src/main/java/net/cattaka/android/adaptertoolbox/classic/AdapterConverter.java
+++ b/adapter-toolbox/src/main/java/net/cattaka/android/adaptertoolbox/classic/AdapterConverter.java
@@ -1,6 +1,5 @@
 package net.cattaka.android.adaptertoolbox.classic;
 
-import android.content.Context;
 import android.database.DataSetObserver;
 import android.support.annotation.IdRes;
 import android.support.annotation.NonNull;
@@ -32,8 +31,11 @@ public class AdapterConverter<
 
     private Map<DataSetObserver, AdapterDataObserver> mAdapterDataObservers = new HashMap<>();
 
-    public AdapterConverter(@NonNull Context context, @NonNull S orig) {
+    public AdapterConverter() {
         super();
+    }
+
+    public void setOriginal(S orig) {
         mOrig = orig;
     }
 

--- a/adapter-toolbox/src/main/java/net/cattaka/android/adaptertoolbox/classic/ClassicScrambleAdapter.java
+++ b/adapter-toolbox/src/main/java/net/cattaka/android/adaptertoolbox/classic/ClassicScrambleAdapter.java
@@ -43,9 +43,10 @@ public class ClassicScrambleAdapter<T> extends AdapterConverter<ScrambleAdapter<
                     RecyclerView.ViewHolder,
                     ForwardingListener<ScrambleAdapter<?>, RecyclerView.ViewHolder>, ?
                     >> iViewHolderFactory) {
-        super(context, new InnerScrambleAdapter<T>(context, items, classicListenerRelay, iViewHolderFactory));
-        InnerScrambleAdapter<T> orig = (InnerScrambleAdapter<T>) getOrig();
+        super();
+        InnerScrambleAdapter<T> orig = new InnerScrambleAdapter<T>(context, items, classicListenerRelay, iViewHolderFactory);
         orig.setParentAdapter(this);
+        setOriginal(orig);
     }
 
     public static class ViewHolder extends RecyclerView.ViewHolder {

--- a/example/src/main/java/net/cattaka/android/adaptertoolbox/example/SpinnerTreeItemAdapterExampleActivity.java
+++ b/example/src/main/java/net/cattaka/android/adaptertoolbox/example/SpinnerTreeItemAdapterExampleActivity.java
@@ -1,6 +1,5 @@
 package net.cattaka.android.adaptertoolbox.example;
 
-import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.design.widget.Snackbar;
@@ -11,6 +10,7 @@ import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.Spinner;
 
+import net.cattaka.android.adaptertoolbox.adapter.listener.ForwardingListener;
 import net.cattaka.android.adaptertoolbox.classic.AdapterConverter;
 import net.cattaka.android.adaptertoolbox.classic.listener.ClassicForwardingListener;
 import net.cattaka.android.adaptertoolbox.classic.listener.ClassicListenerRelay;
@@ -58,9 +58,15 @@ public class SpinnerTreeItemAdapterExampleActivity extends AppCompatActivity imp
         { // set adapter
             List<MyTreeItem> items = ExampleDataGenerator.generateMyTreeItem(Arrays.asList(5, 3, 2), 0);
 
-            SpinnerMyTreeItemAdapter adapter = new SpinnerMyTreeItemAdapter(this, items);
-            mAdapterConverter = new AdapterConverterEx(this, adapter);
-            adapter.setForwardingListener(new ClassicForwardingListener<SpinnerMyTreeItemAdapter, SpinnerMyTreeItemAdapter.ViewHolder>(mAdapterConverter, mListenerRelay));
+            mAdapterConverter = new AdapterConverterEx();
+            SpinnerMyTreeItemAdapter adapter = new SpinnerMyTreeItemAdapter(this, items) {
+                @NonNull
+                @Override
+                public ForwardingListener<SpinnerMyTreeItemAdapter, ViewHolder> createForwardingListener() {
+                    return new ClassicForwardingListener<>(mAdapterConverter, mListenerRelay);
+                }
+            };
+            mAdapterConverter.setOriginal(adapter);
 
             // Issue: Spinner Doesn't Allow Heterogeneous ListAdapters in Lollipop.
             // https://code.google.com/p/android/issues/detail?id=79011
@@ -87,8 +93,8 @@ public class SpinnerTreeItemAdapterExampleActivity extends AppCompatActivity imp
     }
 
     private static class AdapterConverterEx extends AdapterConverter<SpinnerMyTreeItemAdapter, SpinnerMyTreeItemAdapter.ViewHolder, SpinnerMyTreeItemAdapter.WrappedItem> {
-        public AdapterConverterEx(@NonNull Context context, @NonNull SpinnerMyTreeItemAdapter orig) {
-            super(context, orig);
+        public AdapterConverterEx() {
+            super();
         }
 
         @Override

--- a/example/src/main/java/net/cattaka/android/adaptertoolbox/example/adapter/ActivityEntryAdapter.java
+++ b/example/src/main/java/net/cattaka/android/adaptertoolbox/example/adapter/ActivityEntryAdapter.java
@@ -11,6 +11,7 @@ import android.widget.CompoundButton;
 import android.widget.TextView;
 
 import net.cattaka.android.adaptertoolbox.adapter.AbsChoosableTreeItemAdapter;
+import net.cattaka.android.adaptertoolbox.adapter.listener.IForwardingListener;
 import net.cattaka.android.adaptertoolbox.example.R;
 import net.cattaka.android.adaptertoolbox.example.data.ActivityEntry;
 
@@ -45,26 +46,6 @@ public class ActivityEntryAdapter extends AbsChoosableTreeItemAdapter<
         }
     };
 
-    private View.OnClickListener mOnClickListener = new View.OnClickListener() {
-        @Override
-        public void onClick(View view) {
-            RecyclerView recyclerView = getAttachedRecyclerView();
-            ViewHolder vh = (ViewHolder) recyclerView.findContainingViewHolder(view);
-            int position = vh.getAdapterPosition();
-            WrappedItem item = getItemAt(position);
-            switch (view.getId()) {
-                case R.id.check_opened: {
-                    doOpen(item, !item.isOpened());
-                    break;
-                }
-                default: {
-                    toggleCheck(item);
-                    break;
-                }
-            }
-        }
-    };
-
     public ActivityEntryAdapter(Context context, List<ActivityEntry> items) {
         super(context, items, REF);
     }
@@ -75,9 +56,9 @@ public class ActivityEntryAdapter extends AbsChoosableTreeItemAdapter<
         View view = LayoutInflater.from(getContext()).inflate(R.layout.item_activity_entry, parent, false);
         ViewHolder holder = new ViewHolder(view);
 
-        holder.openedCheck.setOnClickListener(mOnClickListener);
+        holder.openedCheck.setOnClickListener(createOnClickListener(parent));
 
-        holder.itemView.setOnClickListener(getForwardingListener());
+        holder.itemView.setOnClickListener(getForwardingListener(parent));
 
         return holder;
     }
@@ -99,6 +80,29 @@ public class ActivityEntryAdapter extends AbsChoosableTreeItemAdapter<
 
         holder.openedCheck.setChecked(wrappedItem.isOpened());
         holder.labelText.setText(item.getLabel(holder.itemView.getResources()));
+    }
+
+    private View.OnClickListener createOnClickListener(View parent) {
+        final IForwardingListener.IProvider<ActivityEntryAdapter, ViewHolder> listenerRelay = getProvider(parent);
+        return new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                RecyclerView recyclerView = listenerRelay.getAttachedRecyclerView();
+                ViewHolder vh = (ViewHolder) recyclerView.findContainingViewHolder(view);
+                int position = vh.getAdapterPosition();
+                WrappedItem item = getItemAt(position);
+                switch (view.getId()) {
+                    case R.id.check_opened: {
+                        doOpen(item, !item.isOpened());
+                        break;
+                    }
+                    default: {
+                        toggleCheck(item);
+                        break;
+                    }
+                }
+            }
+        };
     }
 
     public static class WrappedItem extends AbsChoosableTreeItemAdapter.WrappedItem<WrappedItem, ActivityEntry> {

--- a/example/src/main/java/net/cattaka/android/adaptertoolbox/example/adapter/ChoosableMyTreeItemAdapter.java
+++ b/example/src/main/java/net/cattaka/android/adaptertoolbox/example/adapter/ChoosableMyTreeItemAdapter.java
@@ -11,6 +11,7 @@ import android.widget.CompoundButton;
 import android.widget.TextView;
 
 import net.cattaka.android.adaptertoolbox.adapter.AbsChoosableTreeItemAdapter;
+import net.cattaka.android.adaptertoolbox.adapter.listener.IForwardingListener;
 import net.cattaka.android.adaptertoolbox.example.R;
 import net.cattaka.android.adaptertoolbox.example.data.MyTreeItem;
 
@@ -45,28 +46,6 @@ public class ChoosableMyTreeItemAdapter extends AbsChoosableTreeItemAdapter<
         }
     };
 
-    private View.OnClickListener mOnClickListener = new View.OnClickListener() {
-        @Override
-        public void onClick(View view) {
-            RecyclerView recyclerView = getAttachedRecyclerView();
-            ViewHolder vh = (ViewHolder) (recyclerView != null ? recyclerView.findContainingViewHolder(view) : null);
-            if (vh != null) {
-                int position = vh.getAdapterPosition();
-                WrappedItem item = getItemAt(position);
-                switch (view.getId()) {
-                    case R.id.check_opened: {
-                        doOpen(item, !item.isOpened());
-                        break;
-                    }
-                    default: {
-                        toggleCheck(item);
-                        break;
-                    }
-                }
-            }
-        }
-    };
-
     public ChoosableMyTreeItemAdapter(Context context, List<MyTreeItem> items) {
         super(context, items, REF);
     }
@@ -77,8 +56,8 @@ public class ChoosableMyTreeItemAdapter extends AbsChoosableTreeItemAdapter<
         View view = LayoutInflater.from(getContext()).inflate(R.layout.item_choosable_my_tree_item, parent, false);
         ViewHolder holder = new ViewHolder(view);
 
-        holder.chosenCheck.setOnClickListener(mOnClickListener);
-        holder.openedCheck.setOnClickListener(mOnClickListener);
+        holder.chosenCheck.setOnClickListener(createOnClickListener(parent));
+        holder.openedCheck.setOnClickListener(createOnClickListener(parent));
 
         return holder;
     }
@@ -101,6 +80,31 @@ public class ChoosableMyTreeItemAdapter extends AbsChoosableTreeItemAdapter<
         holder.chosenCheck.setChecked(wrappedItem.isChecked());
         holder.openedCheck.setChecked(wrappedItem.isOpened());
         holder.labelText.setText(item.getText());
+    }
+
+    private View.OnClickListener createOnClickListener(View parent) {
+        final IForwardingListener.IProvider provider = getProvider(parent);
+        return new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                RecyclerView recyclerView = provider.getAttachedRecyclerView();
+                ViewHolder vh = (ViewHolder) (recyclerView != null ? recyclerView.findContainingViewHolder(view) : null);
+                if (vh != null) {
+                    int position = vh.getAdapterPosition();
+                    WrappedItem item = getItemAt(position);
+                    switch (view.getId()) {
+                        case R.id.check_opened: {
+                            doOpen(item, !item.isOpened());
+                            break;
+                        }
+                        default: {
+                            toggleCheck(item);
+                            break;
+                        }
+                    }
+                }
+            }
+        };
     }
 
     public static class WrappedItem extends AbsChoosableTreeItemAdapter.WrappedItem<WrappedItem, MyTreeItem> {

--- a/example/src/main/java/net/cattaka/android/adaptertoolbox/example/adapter/MyTreeItemAdapter.java
+++ b/example/src/main/java/net/cattaka/android/adaptertoolbox/example/adapter/MyTreeItemAdapter.java
@@ -11,6 +11,7 @@ import android.widget.CompoundButton;
 import android.widget.TextView;
 
 import net.cattaka.android.adaptertoolbox.adapter.AbsChoosableTreeItemAdapter;
+import net.cattaka.android.adaptertoolbox.adapter.listener.IForwardingListener;
 import net.cattaka.android.adaptertoolbox.example.R;
 import net.cattaka.android.adaptertoolbox.example.data.MyTreeItem;
 
@@ -45,27 +46,30 @@ public class MyTreeItemAdapter extends AbsChoosableTreeItemAdapter<
         }
     };
 
-    private View.OnClickListener mOnClickListener = new View.OnClickListener() {
-        @Override
-        public void onClick(View view) {
-            RecyclerView recyclerView = getAttachedRecyclerView();
-            ViewHolder vh = (ViewHolder) (recyclerView != null ? recyclerView.findContainingViewHolder(view) : null);
-            if (vh != null) {
-                int position = vh.getAdapterPosition();
-                WrappedItem item = getItemAt(position);
-                switch (view.getId()) {
-                    case R.id.check_opened: {
-                        doOpen(item, !item.isOpened());
-                        break;
-                    }
-                    default: {
-                        toggleCheck(item);
-                        break;
+    private View.OnClickListener createOnClickListener(View parent) {
+        final IForwardingListener.IProvider provider = getProvider(parent);
+        return new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                RecyclerView recyclerView = provider.getAttachedRecyclerView();
+                ViewHolder vh = (ViewHolder) (recyclerView != null ? recyclerView.findContainingViewHolder(view) : null);
+                if (vh != null) {
+                    int position = vh.getAdapterPosition();
+                    WrappedItem item = getItemAt(position);
+                    switch (view.getId()) {
+                        case R.id.check_opened: {
+                            doOpen(item, !item.isOpened());
+                            break;
+                        }
+                        default: {
+                            toggleCheck(item);
+                            break;
+                        }
                     }
                 }
             }
-        }
-    };
+        };
+    }
 
     public MyTreeItemAdapter(Context context, List<MyTreeItem> items) {
         super(context, items, REF);
@@ -77,10 +81,10 @@ public class MyTreeItemAdapter extends AbsChoosableTreeItemAdapter<
         View view = LayoutInflater.from(getContext()).inflate(R.layout.item_my_tree_item, parent, false);
         ViewHolder holder = new ViewHolder(view);
 
-        holder.openedCheck.setOnClickListener(mOnClickListener);
+        holder.openedCheck.setOnClickListener(createOnClickListener(parent));
 
-        holder.itemView.setOnClickListener(getForwardingListener());
-        holder.itemView.setOnLongClickListener(getForwardingListener());
+        holder.itemView.setOnClickListener(getForwardingListener(parent));
+        holder.itemView.setOnLongClickListener(getForwardingListener(parent));
 
         return holder;
     }

--- a/example/src/main/java/net/cattaka/android/adaptertoolbox/example/spinner/SpinnerMyTreeItemAdapter.java
+++ b/example/src/main/java/net/cattaka/android/adaptertoolbox/example/spinner/SpinnerMyTreeItemAdapter.java
@@ -79,7 +79,7 @@ public class SpinnerMyTreeItemAdapter extends AbsTreeItemAdapter<
         holder.openedCheck.setTag(AdapterConverter.VIEW_HOLDER, holder);
         holder.openedCheck.setOnClickListener(mOnClickListener);
 
-        holder.itemView.setOnClickListener(getForwardingListener());
+        holder.itemView.setOnClickListener(getForwardingListener(parent));
 
         return holder;
     }


### PR DESCRIPTION
The method getAttachedRecyclerView() was removed because RecyclerView.Adapter is designed for attaching multiple RecyclerView.

Use getProvider(parentRecyclerView) instead.
- [AbsScrambleAdapter#getProvider(View parent)](https://github.com/cattaka/AdapterToolbox/blob/417c34837619765c50f4f1def358841c4c503fc5/adapter-toolbox/src/main/java/net/cattaka/android/adaptertoolbox/adapter/AbsScrambleAdapter.java#L192)
- [AbsCustomRecyclerAdapter#getProvider(View parent)](https://github.com/cattaka/AdapterToolbox/blob/417c34837619765c50f4f1def358841c4c503fc5/adapter-toolbox/src/main/java/net/cattaka/android/adaptertoolbox/adapter/AbsCustomRecyclerAdapter.java#L88)
