### PR TITLE
Add some protected getter to ForwardingListener

### DIFF
--- a/adapter-toolbox/src/main/java/net/cattaka/android/adaptertoolbox/adapter/listener/ForwardingListener.java
+++ b/adapter-toolbox/src/main/java/net/cattaka/android/adaptertoolbox/adapter/listener/ForwardingListener.java
@@ -33,8 +33,16 @@ public class ForwardingListener<A extends RecyclerView.Adapter<? extends VH>, VH
     public ForwardingListener() {
     }
 
+    protected ListenerRelay<A, VH> getListenerRelay() {
+        return mListenerRelay;
+    }
+
     public void setListenerRelay(@Nullable ListenerRelay<A, VH> listenerRelay) {
         mListenerRelay = listenerRelay;
+    }
+
+    protected IProvider<A, VH> getProvider() {
+        return mProvider;
     }
 
     @Override


### PR DESCRIPTION
In edge case, we need to extend the pair of ForwardingListener and ListenerRelay. But ForwardingListener does not have some getters that provides obtaining methods for a parent RecyclerView.

To avoid this problem, I added protected getters.