### PR TITLE
Rename a method to avoid conflict

### DIFF
--- a/adapter-toolbox/src/main/java/net/cattaka/android/adaptertoolbox/classic/listener/ClassicForwardingListener.java
+++ b/adapter-toolbox/src/main/java/net/cattaka/android/adaptertoolbox/classic/listener/ClassicForwardingListener.java
@@ -42,7 +42,7 @@ public class ClassicForwardingListener<A extends RecyclerView.Adapter<? extends 
         mAdapter = adapter;
     }
 
-    public ClassicListenerRelay getListenerRelay() {
+    public ClassicListenerRelay getClassicListenerRelay() {
         return mListenerRelay;
     }
 


### PR DESCRIPTION
ClassicForwardingListener had same name method...


refs #37 
