### PR TITLE
Disable databinding in library project

### DIFF
--- a/adapter-toolbox/build.gradle
+++ b/adapter-toolbox/build.gradle
@@ -25,7 +25,7 @@ android {
         }
     }
     dataBinding {
-        enabled true
+        enabled false
     }
 }
 


### PR DESCRIPTION
Current `adapter-toolbox` is enabled a databinding.
In my case, Build failed with below logs:

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':*:compile*JavaWithJavac'.
> java.lang.RuntimeException: failure, see logs for details.
  Could not read Binding properties intermediate file. /Users/*/.gradle/caches/modules-2/files-2.1/net.cattaka/adapter-toolbox/0.5.1/e8e45557738ef7e3f602ad68a61d17d4320e46cc/adapter-toolbox-0.5.1.aar java.lang.ClassNotFoundException: android.databinding.tool.store.SetterStore$IntermediateV3
  	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
  	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
  	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
  	at java.lang.Class.forName0(Native Method)
  	at java.lang.Class.forName(Class.java:348)
  	at java.io.ObjectInputStream.resolveClass(ObjectInputStream.java:628)
  	at java.io.ObjectInputStream.readNonProxyDesc(ObjectInputStream.java:1620)
  	at java.io.ObjectInputStream.readClassDesc(ObjectInputStream.java:1521)
  	at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:1781)
  	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1353)
  	at java.io.ObjectInputStream.readObject(ObjectInputStream.java:373)
  	at android.databinding.tool.util.GenerationalClassUtil.fromInputStream(GenerationalClassUtil.java:152)
...
```

This error is occurred when conflict some `databinding` library version.
This issue can be solved by disable `databinding`.

(Why it depends to `databinding` in the first place????)