### PR TITLE
Fix test failes snackbar

### DIFF
--- a/example/src/androidTest/java/net/cattaka/android/adaptertoolbox/example/ClassicScrambleAdapterExampleActivityTest.java
+++ b/example/src/androidTest/java/net/cattaka/android/adaptertoolbox/example/ClassicScrambleAdapterExampleActivityTest.java
@@ -9,7 +9,7 @@ import android.widget.ListView;
 import net.cattaka.android.adaptertoolbox.adapter.ScrambleAdapter;
 import net.cattaka.android.adaptertoolbox.classic.ClassicScrambleAdapter;
 import net.cattaka.android.adaptertoolbox.data.ICodeLabel;
-import net.cattaka.android.adaptertoolbox.example.logic.SnackbarLogic;
+import net.cattaka.android.adaptertoolbox.example.test.MockSnackbarLogic;
 import net.cattaka.android.adaptertoolbox.example.test.TestUtils;
 
 import org.junit.Rule;
@@ -37,7 +37,7 @@ public class ClassicScrambleAdapterExampleActivityTest {
         ClassicScrambleAdapter<Object> csAdapter = (ClassicScrambleAdapter<Object>) activity.mListView.getAdapter();
         ScrambleAdapter<Object> adapter = csAdapter.getOrig();
 
-        activity.mSnackbarLogic = spy(new SnackbarLogic());
+        activity.mSnackbarLogic = spy(new MockSnackbarLogic());
 
         {
             TestUtils.Entry<Number> entry = TestUtils.find(adapter.getItems(), Number.class, 2);

--- a/example/src/androidTest/java/net/cattaka/android/adaptertoolbox/example/CodeLabelExampleActivityTest.java
+++ b/example/src/androidTest/java/net/cattaka/android/adaptertoolbox/example/CodeLabelExampleActivityTest.java
@@ -5,7 +5,7 @@ import android.support.test.rule.ActivityTestRule;
 import android.view.View;
 
 import net.cattaka.android.adaptertoolbox.example.data.OrdinalLabel;
-import net.cattaka.android.adaptertoolbox.example.logic.SnackbarLogic;
+import net.cattaka.android.adaptertoolbox.example.test.MockSnackbarLogic;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -31,7 +31,7 @@ public class CodeLabelExampleActivityTest {
     @Test
     public void clickSpinner() {
         CodeLabelExampleActivity activity = mActivityTestRule.launchActivity(null);
-        activity.mSnackbarLogic = spy(new SnackbarLogic());
+        activity.mSnackbarLogic = spy(new MockSnackbarLogic());
 
         for (OrdinalLabel item : OrdinalLabel.values()) {
             onView(withId(R.id.spinner)).perform(click());

--- a/example/src/androidTest/java/net/cattaka/android/adaptertoolbox/example/ComplexStringExampleActivityTest.java
+++ b/example/src/androidTest/java/net/cattaka/android/adaptertoolbox/example/ComplexStringExampleActivityTest.java
@@ -4,7 +4,7 @@ import android.support.test.rule.ActivityTestRule;
 import android.view.View;
 
 import net.cattaka.android.adaptertoolbox.adapter.ScrambleAdapter;
-import net.cattaka.android.adaptertoolbox.example.logic.SnackbarLogic;
+import net.cattaka.android.adaptertoolbox.example.test.MockSnackbarLogic;
 import net.cattaka.android.adaptertoolbox.example.test.TestUtils;
 
 import org.junit.Rule;
@@ -34,7 +34,7 @@ public class ComplexStringExampleActivityTest {
         ComplexStringExampleActivity activity = mActivityTestRule.launchActivity(null);
         ScrambleAdapter<String> adapter = (ScrambleAdapter<String>) activity.mRecyclerView.getAdapter();
 
-        activity.mSnackbarLogic = spy(new SnackbarLogic());
+        activity.mSnackbarLogic = spy(new MockSnackbarLogic());
 
         for (int i = 0; i < 10; i++) {
             TestUtils.Entry<String> item = TestUtils.find(adapter.getItems(), String.class, i);

--- a/example/src/androidTest/java/net/cattaka/android/adaptertoolbox/example/DataBindingManipulableListExampleActivityTest.java
+++ b/example/src/androidTest/java/net/cattaka/android/adaptertoolbox/example/DataBindingManipulableListExampleActivityTest.java
@@ -6,7 +6,7 @@ import android.support.test.rule.ActivityTestRule;
 import net.cattaka.android.adaptertoolbox.adapter.ScrambleAdapter;
 import net.cattaka.android.adaptertoolbox.example.data.ObservableMyInfo;
 import net.cattaka.android.adaptertoolbox.example.data.OrdinalLabel;
-import net.cattaka.android.adaptertoolbox.example.logic.SnackbarLogic;
+import net.cattaka.android.adaptertoolbox.example.test.MockSnackbarLogic;
 import net.cattaka.android.adaptertoolbox.example.test.TestUtils;
 import net.cattaka.android.adaptertoolbox.thirdparty.MergeRecyclerAdapter;
 
@@ -41,7 +41,7 @@ public class DataBindingManipulableListExampleActivityTest {
         ScrambleAdapter headerAdapter = (ScrambleAdapter) mergeRecyclerAdapter.getSubAdapter(0);
         ScrambleAdapter adapter = (ScrambleAdapter) mergeRecyclerAdapter.getSubAdapter(1);
 
-        activity.mSnackbarLogic = spy(new SnackbarLogic());
+        activity.mSnackbarLogic = spy(new MockSnackbarLogic());
 
         {   // Edit MyInfo
             int position = 1;

--- a/example/src/androidTest/java/net/cattaka/android/adaptertoolbox/example/FizzBuzzExampleActivityTest.java
+++ b/example/src/androidTest/java/net/cattaka/android/adaptertoolbox/example/FizzBuzzExampleActivityTest.java
@@ -3,7 +3,7 @@ package net.cattaka.android.adaptertoolbox.example;
 import android.support.test.rule.ActivityTestRule;
 import android.view.View;
 
-import net.cattaka.android.adaptertoolbox.example.logic.SnackbarLogic;
+import net.cattaka.android.adaptertoolbox.example.test.MockSnackbarLogic;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -32,7 +32,7 @@ public class FizzBuzzExampleActivityTest {
     public void click_FizzBuzz() {
         FizzBuzzExampleActivity activity = mActivityTestRule.launchActivity(null);
 
-        activity.mSnackbarLogic = spy(new SnackbarLogic());
+        activity.mSnackbarLogic = spy(new MockSnackbarLogic());
 
         {   // Click Integer
             int target = 2;
@@ -72,7 +72,7 @@ public class FizzBuzzExampleActivityTest {
     public void click_Fizz() {
         FizzBuzzExampleActivity activity = mActivityTestRule.launchActivity(null);
 
-        activity.mSnackbarLogic = spy(new SnackbarLogic());
+        activity.mSnackbarLogic = spy(new MockSnackbarLogic());
 
         // Disable buzz
         onView(withId(R.id.check_buzz)).perform(click());
@@ -115,7 +115,7 @@ public class FizzBuzzExampleActivityTest {
     public void click_Buzz() {
         FizzBuzzExampleActivity activity = mActivityTestRule.launchActivity(null);
 
-        activity.mSnackbarLogic = spy(new SnackbarLogic());
+        activity.mSnackbarLogic = spy(new MockSnackbarLogic());
 
         // Disable fizz
         onView(withId(R.id.check_fizz)).perform(click());
@@ -158,7 +158,7 @@ public class FizzBuzzExampleActivityTest {
     public void click_Integer() {
         FizzBuzzExampleActivity activity = mActivityTestRule.launchActivity(null);
 
-        activity.mSnackbarLogic = spy(new SnackbarLogic());
+        activity.mSnackbarLogic = spy(new MockSnackbarLogic());
 
         // Disable fizz buzz
         onView(withId(R.id.check_fizz)).perform(click());

--- a/example/src/androidTest/java/net/cattaka/android/adaptertoolbox/example/ManipulableListExampleActivityTest.java
+++ b/example/src/androidTest/java/net/cattaka/android/adaptertoolbox/example/ManipulableListExampleActivityTest.java
@@ -7,7 +7,7 @@ import net.cattaka.android.adaptertoolbox.adapter.ScrambleAdapter;
 import net.cattaka.android.adaptertoolbox.example.data.MyInfo;
 import net.cattaka.android.adaptertoolbox.example.data.OrdinalLabel;
 import net.cattaka.android.adaptertoolbox.example.data.TextInfo;
-import net.cattaka.android.adaptertoolbox.example.logic.SnackbarLogic;
+import net.cattaka.android.adaptertoolbox.example.test.MockSnackbarLogic;
 import net.cattaka.android.adaptertoolbox.example.test.TestUtils;
 import net.cattaka.android.adaptertoolbox.thirdparty.MergeRecyclerAdapter;
 
@@ -44,7 +44,7 @@ public class ManipulableListExampleActivityTest {
         ScrambleAdapter headerAdapter = (ScrambleAdapter) mergeRecyclerAdapter.getSubAdapter(0);
         ScrambleAdapter adapter = (ScrambleAdapter) mergeRecyclerAdapter.getSubAdapter(1);
 
-        activity.mSnackbarLogic = spy(new SnackbarLogic());
+        activity.mSnackbarLogic = spy(new MockSnackbarLogic());
 
         {   // Edit MyInfo
             int position = 1;
@@ -88,7 +88,7 @@ public class ManipulableListExampleActivityTest {
         ScrambleAdapter headerAdapter = (ScrambleAdapter) mergeRecyclerAdapter.getSubAdapter(0);
         ScrambleAdapter adapter = (ScrambleAdapter) mergeRecyclerAdapter.getSubAdapter(1);
 
-        activity.mSnackbarLogic = spy(new SnackbarLogic());
+        activity.mSnackbarLogic = spy(new MockSnackbarLogic());
 
         {   // Edit TextInfo
             int position = 2;

--- a/example/src/androidTest/java/net/cattaka/android/adaptertoolbox/example/MultiAdapterExampleActivityTest.java
+++ b/example/src/androidTest/java/net/cattaka/android/adaptertoolbox/example/MultiAdapterExampleActivityTest.java
@@ -4,6 +4,7 @@ import android.support.test.rule.ActivityTestRule;
 import android.view.View;
 
 import net.cattaka.android.adaptertoolbox.example.logic.SnackbarLogic;
+import net.cattaka.android.adaptertoolbox.example.test.MockSnackbarLogic;
 import net.cattaka.android.adaptertoolbox.example.test.TestUtils;
 import net.cattaka.android.adaptertoolbox.thirdparty.MergeRecyclerAdapter;
 
@@ -36,7 +37,7 @@ public class MultiAdapterExampleActivityTest {
         MultiAdapterExampleActivity activity = mActivityTestRule.launchActivity(null);
         MergeRecyclerAdapter mergeRecyclerAdapter = activity.mMergeRecyclerAdapter;
 
-        activity.mSnackbarLogic = spy(new SnackbarLogic());
+        activity.mSnackbarLogic = spy(new MockSnackbarLogic());
 
         {
             int globalPosition = TestUtils.calcPositionOffset(mergeRecyclerAdapter, activity.mStringsHeaderAdapter);

--- a/example/src/androidTest/java/net/cattaka/android/adaptertoolbox/example/MultiChoosableTreeItemAdapterExampleActivityTest.java
+++ b/example/src/androidTest/java/net/cattaka/android/adaptertoolbox/example/MultiChoosableTreeItemAdapterExampleActivityTest.java
@@ -5,7 +5,7 @@ import android.view.View;
 
 import net.cattaka.android.adaptertoolbox.example.adapter.ChoosableMyTreeItemAdapter;
 import net.cattaka.android.adaptertoolbox.example.data.MyTreeItem;
-import net.cattaka.android.adaptertoolbox.example.logic.SnackbarLogic;
+import net.cattaka.android.adaptertoolbox.example.test.MockSnackbarLogic;
 import net.cattaka.android.adaptertoolbox.example.test.RecyclerViewAnimatingIdlingResource;
 import net.cattaka.android.adaptertoolbox.example.test.TestUtils;
 
@@ -54,7 +54,7 @@ public class MultiChoosableTreeItemAdapterExampleActivityTest {
         MultiChoosableTreeItemAdapterExampleActivity activity = mActivityTestRule.getActivity();
         ChoosableMyTreeItemAdapter adapter = activity.mAdapter;
 
-        activity.mSnackbarLogic = spy(new SnackbarLogic());
+        activity.mSnackbarLogic = spy(new MockSnackbarLogic());
 
         for (int i = 0; i < adapter.getItemCount(); i++) {
             TestUtils.Entry<ChoosableMyTreeItemAdapter.WrappedItem> entry = find(adapter.getItems(), ChoosableMyTreeItemAdapter.WrappedItem.class, i);
@@ -81,7 +81,7 @@ public class MultiChoosableTreeItemAdapterExampleActivityTest {
         MultiChoosableTreeItemAdapterExampleActivity activity = mActivityTestRule.getActivity();
         ChoosableMyTreeItemAdapter adapter = activity.mAdapter;
 
-        activity.mSnackbarLogic = spy(new SnackbarLogic());
+        activity.mSnackbarLogic = spy(new MockSnackbarLogic());
 
         MyTreeItem item3 = adapter.getItemAt(3).item;
         MyTreeItem item5 = adapter.getItemAt(5).item;

--- a/example/src/androidTest/java/net/cattaka/android/adaptertoolbox/example/NestedScrambleAdapterExampleActivityTest.java
+++ b/example/src/androidTest/java/net/cattaka/android/adaptertoolbox/example/NestedScrambleAdapterExampleActivityTest.java
@@ -8,7 +8,7 @@ import android.view.View;
 import net.cattaka.android.adaptertoolbox.adapter.ScrambleAdapter;
 import net.cattaka.android.adaptertoolbox.example.data.NestedScrambleInfo;
 import net.cattaka.android.adaptertoolbox.example.data.OrdinalLabel;
-import net.cattaka.android.adaptertoolbox.example.logic.SnackbarLogic;
+import net.cattaka.android.adaptertoolbox.example.test.MockSnackbarLogic;
 import net.cattaka.android.adaptertoolbox.example.test.TestUtils.Entry;
 
 import org.junit.Before;
@@ -44,7 +44,7 @@ public class NestedScrambleAdapterExampleActivityTest {
     public void before() {
         mActivity = mActivityTestRule.launchActivity(null);
         mAdapter = mActivity.mAdapter;
-        mActivity.mSnackbarLogic = spy(new SnackbarLogic());
+        mActivity.mSnackbarLogic = spy(new MockSnackbarLogic());
     }
 
     @Test

--- a/example/src/androidTest/java/net/cattaka/android/adaptertoolbox/example/RecyclerViewHeaderExampleActivityTest.java
+++ b/example/src/androidTest/java/net/cattaka/android/adaptertoolbox/example/RecyclerViewHeaderExampleActivityTest.java
@@ -3,7 +3,7 @@ package net.cattaka.android.adaptertoolbox.example;
 import android.support.test.rule.ActivityTestRule;
 import android.view.View;
 
-import net.cattaka.android.adaptertoolbox.example.logic.SnackbarLogic;
+import net.cattaka.android.adaptertoolbox.example.test.MockSnackbarLogic;
 import net.cattaka.android.adaptertoolbox.example.test.TestUtils;
 import net.cattaka.android.adaptertoolbox.thirdparty.MergeRecyclerAdapter;
 
@@ -35,7 +35,7 @@ public class RecyclerViewHeaderExampleActivityTest {
         RecyclerViewHeaderExampleActivity activity = mActivityTestRule.launchActivity(null);
         MergeRecyclerAdapter mergeRecyclerAdapter = activity.mMergeRecyclerAdapter;
 
-        activity.mSnackbarLogic = spy(new SnackbarLogic());
+        activity.mSnackbarLogic = spy(new MockSnackbarLogic());
 
         {
             int globalPosition = TestUtils.calcPositionOffset(mergeRecyclerAdapter, activity.mHeaderAdapter);

--- a/example/src/androidTest/java/net/cattaka/android/adaptertoolbox/example/ScrambleAdapterExampleActivityTest.java
+++ b/example/src/androidTest/java/net/cattaka/android/adaptertoolbox/example/ScrambleAdapterExampleActivityTest.java
@@ -6,7 +6,7 @@ import android.view.View;
 
 import net.cattaka.android.adaptertoolbox.adapter.ScrambleAdapter;
 import net.cattaka.android.adaptertoolbox.example.data.OrdinalLabel;
-import net.cattaka.android.adaptertoolbox.example.logic.SnackbarLogic;
+import net.cattaka.android.adaptertoolbox.example.test.MockSnackbarLogic;
 import net.cattaka.android.adaptertoolbox.example.test.RecyclerViewAnimatingIdlingResource;
 import net.cattaka.android.adaptertoolbox.example.test.TestUtils;
 
@@ -46,7 +46,7 @@ public class ScrambleAdapterExampleActivityTest {
     public void before() {
         mActivity = mActivityTestRule.launchActivity(null);
         mAdapter = (ScrambleAdapter<Object>) mActivity.mRecyclerView.getAdapter();
-        mActivity.mSnackbarLogic = spy(new SnackbarLogic());
+        mActivity.mSnackbarLogic = spy(new MockSnackbarLogic());
         mRecyclerViewAnimatingIdlingResource = new RecyclerViewAnimatingIdlingResource(mActivity.mRecyclerView);
     }
 

--- a/example/src/androidTest/java/net/cattaka/android/adaptertoolbox/example/SimpleStringExampleActivityTest.java
+++ b/example/src/androidTest/java/net/cattaka/android/adaptertoolbox/example/SimpleStringExampleActivityTest.java
@@ -4,7 +4,7 @@ import android.support.test.rule.ActivityTestRule;
 import android.view.View;
 
 import net.cattaka.android.adaptertoolbox.adapter.ScrambleAdapter;
-import net.cattaka.android.adaptertoolbox.example.logic.SnackbarLogic;
+import net.cattaka.android.adaptertoolbox.example.test.MockSnackbarLogic;
 import net.cattaka.android.adaptertoolbox.example.test.RecyclerViewAnimatingIdlingResource;
 import net.cattaka.android.adaptertoolbox.example.test.TestUtils;
 
@@ -43,7 +43,7 @@ public class SimpleStringExampleActivityTest {
     public void before() {
         mActivity = mActivityTestRule.launchActivity(null);
         mAdapter = (ScrambleAdapter<Object>) mActivity.mRecyclerView.getAdapter();
-        mActivity.mSnackbarLogic = spy(new SnackbarLogic());
+        mActivity.mSnackbarLogic = spy(new MockSnackbarLogic());
         mRecyclerViewAnimatingIdlingResource = new RecyclerViewAnimatingIdlingResource(mActivity.mRecyclerView);
     }
 

--- a/example/src/androidTest/java/net/cattaka/android/adaptertoolbox/example/SingleChoosableTreeItemAdapterExampleActivityTest.java
+++ b/example/src/androidTest/java/net/cattaka/android/adaptertoolbox/example/SingleChoosableTreeItemAdapterExampleActivityTest.java
@@ -5,7 +5,7 @@ import android.view.View;
 
 import net.cattaka.android.adaptertoolbox.example.adapter.ChoosableMyTreeItemAdapter;
 import net.cattaka.android.adaptertoolbox.example.data.MyTreeItem;
-import net.cattaka.android.adaptertoolbox.example.logic.SnackbarLogic;
+import net.cattaka.android.adaptertoolbox.example.test.MockSnackbarLogic;
 import net.cattaka.android.adaptertoolbox.example.test.RecyclerViewAnimatingIdlingResource;
 import net.cattaka.android.adaptertoolbox.example.test.TestUtils;
 
@@ -55,7 +55,7 @@ public class SingleChoosableTreeItemAdapterExampleActivityTest {
         SingleChoosableTreeItemAdapterExampleActivity activity = mActivityTestRule.getActivity();
         ChoosableMyTreeItemAdapter adapter = activity.mAdapter;
 
-        activity.mSnackbarLogic = spy(new SnackbarLogic());
+        activity.mSnackbarLogic = spy(new MockSnackbarLogic());
 
         for (int i = 0; i < adapter.getItemCount(); i++) {
             TestUtils.Entry<ChoosableMyTreeItemAdapter.WrappedItem> entry = find(adapter.getItems(), ChoosableMyTreeItemAdapter.WrappedItem.class, i);
@@ -82,7 +82,7 @@ public class SingleChoosableTreeItemAdapterExampleActivityTest {
         SingleChoosableTreeItemAdapterExampleActivity activity = mActivityTestRule.getActivity();
         ChoosableMyTreeItemAdapter adapter = activity.mAdapter;
 
-        activity.mSnackbarLogic = spy(new SnackbarLogic());
+        activity.mSnackbarLogic = spy(new MockSnackbarLogic());
 
         MyTreeItem item3 = adapter.getItemAt(3).item;
         MyTreeItem item5 = adapter.getItemAt(5).item;

--- a/example/src/androidTest/java/net/cattaka/android/adaptertoolbox/example/SpinnerScrambleAdapterExampleActivityTest.java
+++ b/example/src/androidTest/java/net/cattaka/android/adaptertoolbox/example/SpinnerScrambleAdapterExampleActivityTest.java
@@ -4,7 +4,7 @@ import android.support.test.rule.ActivityTestRule;
 import android.view.View;
 
 import net.cattaka.android.adaptertoolbox.classic.ClassicScrambleAdapter;
-import net.cattaka.android.adaptertoolbox.example.logic.SnackbarLogic;
+import net.cattaka.android.adaptertoolbox.example.test.MockSnackbarLogic;
 import net.cattaka.android.adaptertoolbox.example.test.TestUtils.Entry;
 
 import org.junit.Before;
@@ -38,7 +38,7 @@ public class SpinnerScrambleAdapterExampleActivityTest {
     public void before() {
         mActivity = mActivityTestRule.launchActivity(null);
         mAdapter = (ClassicScrambleAdapter<Object>) mActivity.mSpinner.getAdapter();
-        mActivity.mSnackbarLogic = spy(new SnackbarLogic());
+        mActivity.mSnackbarLogic = spy(new MockSnackbarLogic());
     }
 
     @Test

--- a/example/src/androidTest/java/net/cattaka/android/adaptertoolbox/example/SpinnerTreeItemAdapterExampleActivityTest.java
+++ b/example/src/androidTest/java/net/cattaka/android/adaptertoolbox/example/SpinnerTreeItemAdapterExampleActivityTest.java
@@ -4,9 +4,9 @@ import android.support.test.rule.ActivityTestRule;
 import android.view.View;
 
 import net.cattaka.android.adaptertoolbox.classic.AdapterConverter;
-import net.cattaka.android.adaptertoolbox.example.logic.SnackbarLogic;
 import net.cattaka.android.adaptertoolbox.example.spinner.SpinnerMyTreeItemAdapter;
 import net.cattaka.android.adaptertoolbox.example.spinner.SpinnerMyTreeItemAdapter.WrappedItem;
+import net.cattaka.android.adaptertoolbox.example.test.MockSnackbarLogic;
 import net.cattaka.android.adaptertoolbox.example.test.TestUtils;
 import net.cattaka.android.adaptertoolbox.example.test.TestUtils.Entry;
 
@@ -43,7 +43,7 @@ public class SpinnerTreeItemAdapterExampleActivityTest {
         mActivity = mActivityTestRule.launchActivity(null);
         mAdapterConverter = (AdapterConverter<SpinnerMyTreeItemAdapter, SpinnerMyTreeItemAdapter.ViewHolder, WrappedItem>) mActivity.mSpinner.getAdapter();
         mAdapter = mAdapterConverter.getOrig();
-        mActivity.mSnackbarLogic = spy(new SnackbarLogic());
+        mActivity.mSnackbarLogic = spy(new MockSnackbarLogic());
     }
 
     @Test

--- a/example/src/androidTest/java/net/cattaka/android/adaptertoolbox/example/TreeItemAdapterExampleActivityTest.java
+++ b/example/src/androidTest/java/net/cattaka/android/adaptertoolbox/example/TreeItemAdapterExampleActivityTest.java
@@ -5,7 +5,7 @@ import android.view.View;
 
 import net.cattaka.android.adaptertoolbox.example.adapter.MyTreeItemAdapter;
 import net.cattaka.android.adaptertoolbox.example.data.MyTreeItem;
-import net.cattaka.android.adaptertoolbox.example.logic.SnackbarLogic;
+import net.cattaka.android.adaptertoolbox.example.test.MockSnackbarLogic;
 import net.cattaka.android.adaptertoolbox.example.test.RecyclerViewAnimatingIdlingResource;
 import net.cattaka.android.adaptertoolbox.example.test.TestUtils;
 
@@ -54,7 +54,7 @@ public class TreeItemAdapterExampleActivityTest {
         TreeItemAdapterExampleActivity activity = mActivityTestRule.getActivity();
         MyTreeItemAdapter adapter = (MyTreeItemAdapter) activity.mRecyclerView.getAdapter();
 
-        activity.mSnackbarLogic = spy(new SnackbarLogic());
+        activity.mSnackbarLogic = spy(new MockSnackbarLogic());
 
         for (int i = 0; i < adapter.getItemCount(); i++) {
             TestUtils.Entry<MyTreeItemAdapter.WrappedItem> entry = find(adapter.getItems(), MyTreeItemAdapter.WrappedItem.class, i);
@@ -81,7 +81,7 @@ public class TreeItemAdapterExampleActivityTest {
         TreeItemAdapterExampleActivity activity = mActivityTestRule.getActivity();
         MyTreeItemAdapter adapter = (MyTreeItemAdapter) activity.mRecyclerView.getAdapter();
 
-        activity.mSnackbarLogic = spy(new SnackbarLogic());
+        activity.mSnackbarLogic = spy(new MockSnackbarLogic());
 
         for (int i = 0; i < adapter.getItemCount(); i++) {
             reset(activity.mSnackbarLogic);

--- a/example/src/androidTest/java/net/cattaka/android/adaptertoolbox/example/test/MockSnackbarLogic.java
+++ b/example/src/androidTest/java/net/cattaka/android/adaptertoolbox/example/test/MockSnackbarLogic.java
@@ -1,0 +1,27 @@
+package net.cattaka.android.adaptertoolbox.example.test;
+
+import android.support.annotation.NonNull;
+import android.view.View;
+
+import net.cattaka.android.adaptertoolbox.example.logic.SnackbarLogic;
+
+public class MockSnackbarLogic extends SnackbarLogic {
+    @NonNull
+    @Override
+    public ISnackbarWrapper make(@NonNull View view, @NonNull CharSequence text, int duration) {
+        return new MockSnackbarWrapper();
+    }
+
+    @NonNull
+    @Override
+    public ISnackbarWrapper make(@NonNull View view, int resId, int duration) {
+        return new MockSnackbarWrapper();
+    }
+
+    public static class MockSnackbarWrapper implements ISnackbarWrapper {
+        @Override
+        public void show() {
+            // no-op
+        }
+    }
+}

--- a/example/src/main/java/net/cattaka/android/adaptertoolbox/example/logic/SnackbarLogic.java
+++ b/example/src/main/java/net/cattaka/android/adaptertoolbox/example/logic/SnackbarLogic.java
@@ -13,12 +13,32 @@ public class SnackbarLogic {
     }
 
     @NonNull
-    public Snackbar make(@NonNull View view, @NonNull CharSequence text, int duration) {
-        return Snackbar.make(view, text, duration);
+    public ISnackbarWrapper make(@NonNull View view, @NonNull CharSequence text, int duration) {
+        return new SnackbarWrapperImpl(Snackbar.make(view, text, duration));
     }
 
     @NonNull
-    public Snackbar make(@NonNull View view, @StringRes int resId, int duration) {
-        return Snackbar.make(view, resId, duration);
+    public ISnackbarWrapper make(@NonNull View view, @StringRes int resId, int duration) {
+        return new SnackbarWrapperImpl(Snackbar.make(view, resId, duration));
+    }
+
+    /**
+     * For InstrumentationTest
+     */
+    public interface ISnackbarWrapper {
+        void show();
+    }
+
+    private static class SnackbarWrapperImpl implements ISnackbarWrapper {
+        private Snackbar orig;
+
+        public SnackbarWrapperImpl(Snackbar orig) {
+            this.orig = orig;
+        }
+
+        @Override
+        public void show() {
+            orig.show();
+        }
     }
 }


### PR DESCRIPTION
In some tests, Snackbar appear in front of button and block click event from espresso.
To avoid this issue, I improve Snackbar logic to prevent appearing Snackber during test.